### PR TITLE
Mac install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,16 +8,18 @@ make:
 	gcc -o ./bin/bimp -Wall -O2 -Wno-unused-variable -Wno-pointer-sign -Wno-parentheses src/*.c src/manipulation-gui/*.c $(GIMPARGS) $(PCREARGS) -lm -DGIMP_DISABLE_DEPRECATED
 	
 install: 
+	mkdir -p "$(USER_INSTALL_DIR)"
 	gimptool-2.0 --install-bin ./bin/bimp
-	cp -Rf ./bimp-locale/ $(USER_INSTALL_DIR)
+	cp -Rf ./bimp-locale/ "$(USER_INSTALL_DIR)"
 	
 uninstall: 
 	gimptool-2.0 --uninstall-bin bimp
 	rm -R $(USER_INSTALL_DIR)/bimp-locale
 
 install-admin:
+	mkdir -p "$(SYSTEM_INSTALL_DIR)"
 	gimptool-2.0 --install-admin-bin ./bin/bimp
-	cp -Rf ./bimp-locale/ $(SYSTEM_INSTALL_DIR)
+	cp -Rf ./bimp-locale/ "$(SYSTEM_INSTALL_DIR)"
 
 uninstall-admin:
 	gimptool-2.0 --uninstall-admin-bin bimp

--- a/README.md
+++ b/README.md
@@ -44,7 +44,23 @@ For Mac OSX users
 -----------------
 There's no need to install or compile BIMP on Mac, because the default native build of GIMP for Mac OSX 10.8 
 made by Simone from http://gimp.lisanet.de/Website/Download.html already includes BIMP!
-(however, it's not guaranteed to be the very latest version)
+(however, it's not guaranteed to be the very latest version of either BIMP or GIMP)
+
+For those interested in remaining on the cutting edge, the instructions are as follows:
+
+1. Install [MacPorts](https://www.macports.org/install.php)
+2. Install prerequisites: `sudo port install coreutils pcre `
+3. Add `/opt/local/libexec/gnubin` to your `PATH` to make them the GNU tools the default: `PATH=/opt/local/libexec/gnubin:$PATH`  (You can also add this to your login profile if you want the change to be permanent).
+3. Install GIMP with MacPorts: `sudo port install gimp +quartz` (You can leave off the `+quartz` if you prefer GIMP to run in the X11 environment instead of natively.)
+4. Follow the build and install instructions for Linux.
+5. Look at the output for the install command.  If your plug-in directory contains a space in its name (as would happen if it is in the `Application Support` folder), then there will be a copy command which failed listed.  You will need to perform that copy command manually with the destination directory properly wrapped in quotes.  I.e. if you see
+```
+cp ./bin/bimp /Users/NAME/Library/Application Support/GIMP/2.8/plug-ins
+cp: target 'Support/GIMP/2.8/plug-ins' is not a directory
+```
+    Then you need to do `cp ./bin/bimp "/Users/NAME/Library/Application Support/GIMP/2.8/plug-ins"`.
+
+*Note:* Even though you have to install GIMP from MacPorts in order to build the binaries for BIMP, they should work just fine with the self-contained GIMP build from gimp.org.  In fact, you could probably uninstall the MacPorts version once the binaries are built, but you'll need to reinstall it each time you want to update BIMP.
 
 
 Support this project


### PR DESCRIPTION
These more explicit Mac instructions (and the accompanying changes to the Makefile) should help those Mac users who for some reason cannot (or don't want) to use the linked pre-compiled GIMP for Mac.  In my case, it's because the pre-compiled versions are out-of-date, but the instructions would also address #111.