### PR TITLE
Compile under GCC10 without -fcommon

### DIFF
--- a/src/bimp-gui.c
+++ b/src/bimp-gui.c
@@ -55,18 +55,20 @@ static void progressbar_end_hidden (gpointer);
 static void progressbar_settext_hidden (const gchar*, gpointer);
 static void progressbar_setvalue_hidden (double, gpointer);
 
-GtkWidget *panel_sequence, *panel_options;
-GtkWidget *hbox_sequence;
-GtkWidget *scroll_sequence;
-GtkWidget *popmenu_add, *popmenu_edit, *popmenu_addfiles, *popmenu_removefiles;
-GtkWidget *check_keepfolderhierarchy, *check_deleteondone, *check_keepdates;
-GtkWidget *treeview_files;
-GtkWidget *button_preview, *button_outfolder, *button_samefolder;
-GtkWidget* progressbar_visible;
+GtkWidget* bimp_window_main;
 
-char* selected_source_folder;
-char* last_input_location;
-const gchar* progressbar_data;
+static GtkWidget *panel_sequence, *panel_options;
+static GtkWidget *hbox_sequence;
+static GtkWidget *scroll_sequence;
+static GtkWidget *popmenu_add, *popmenu_edit, *popmenu_addfiles, *popmenu_removefiles;
+static GtkWidget *check_keepfolderhierarchy, *check_deleteondone, *check_keepdates;
+static GtkWidget *treeview_files;
+static GtkWidget *button_preview, *button_outfolder, *button_samefolder;
+static GtkWidget* progressbar_visible;
+
+static char* selected_source_folder;
+static char* last_input_location;
+static const gchar* progressbar_data;
 
 enum /* TreeView stuff... */
 {
@@ -74,7 +76,7 @@ enum /* TreeView stuff... */
   N_COLUMNS
 };
 
-manipulation clicked_man; /* temporary manipulation, selected by clicking on panel_seq buttons */
+static manipulation clicked_man; /* temporary manipulation, selected by clicking on panel_seq buttons */
 
 void bimp_show_gui() 
 {	

--- a/src/bimp-gui.h
+++ b/src/bimp-gui.h
@@ -21,6 +21,6 @@ void bimp_progress_bar_set(double, char*);
 void bimp_show_error_dialog(char*, GtkWidget*);
 void bimp_set_busy(gboolean);
 
-GtkWidget* bimp_window_main;
+extern GtkWidget* bimp_window_main;
 
 #endif

--- a/src/bimp-manipulations.c
+++ b/src/bimp-manipulations.c
@@ -8,6 +8,9 @@
 #include "bimp-manipulations-gui.h"
 #include "plugin-intl.h"
 
+
+GSList* bimp_selected_manipulations;
+
 /* Appends a default manipulation to the step list */
 manipulation bimp_append_manipulation(manipulation_type type)
 {

--- a/src/bimp-manipulations.h
+++ b/src/bimp-manipulations.h
@@ -278,6 +278,6 @@ manipulation manipulation_changeformat_new(void);
 manipulation manipulation_rename_new(void); 
 manipulation manipulation_userdef_new(void); 
 
-GSList* bimp_selected_manipulations; /* Manipulations selected by user */
+extern GSList* bimp_selected_manipulations; /* Manipulations selected by user */
 
 #endif

--- a/src/bimp-operate.c
+++ b/src/bimp-operate.c
@@ -43,31 +43,31 @@ static gboolean image_save_exr(image_output);
 
 static int overwrite_result(char*, GtkWidget*);
 
-char* current_datetime;
-int processed_count;
-int success_count;
-int total_images;
+static char* current_datetime;
+static int processed_count;
+static int success_count;
+static int total_images;
 
-char* common_folder_path;
+static char* common_folder_path;
 
-gboolean list_contains_changeformat;
-gboolean list_contains_rename;
-gboolean list_contains_watermark;
-gboolean list_contains_savingplugin;
+static gboolean list_contains_changeformat;
+static gboolean list_contains_rename;
+static gboolean list_contains_watermark;
+static gboolean list_contains_savingplugin;
 
 // set of variables to be used when doing Curve color correction
 // they are global so the batch process will read the source curve file once
-gboolean colorcurve_init;
-int colorcurve_num_points_v;
-gdouble* colorcurve_ctr_points_v;
-int colorcurve_num_points_r;
-gdouble* colorcurve_ctr_points_r;
-int colorcurve_num_points_g;
-gdouble* colorcurve_ctr_points_g;
-int colorcurve_num_points_b;
-gdouble* colorcurve_ctr_points_b;
-int colorcurve_num_points_a;
-gdouble* colorcurve_ctr_points_a;
+static gboolean colorcurve_init;
+static int colorcurve_num_points_v;
+static gdouble* colorcurve_ctr_points_v;
+static int colorcurve_num_points_r;
+static gdouble* colorcurve_ctr_points_r;
+static int colorcurve_num_points_g;
+static gdouble* colorcurve_ctr_points_g;
+static int colorcurve_num_points_b;
+static gdouble* colorcurve_ctr_points_b;
+static int colorcurve_num_points_a;
+static gdouble* colorcurve_ctr_points_a;
 
 void bimp_start_batch(gpointer parent_dialog)
 {

--- a/src/bimp-serialize.c
+++ b/src/bimp-serialize.c
@@ -36,8 +36,8 @@ static manipulation read_rename(GKeyFile*);
 static void write_userdef(userdef_settings, GKeyFile*, int);
 static manipulation read_userdef(GKeyFile*, int);
 
-int userdef_count;
-int loaded_build;
+static int userdef_count;
+static int loaded_build;
 
 gboolean bimp_serialize_to_file(gchar* filename)
 {

--- a/src/bimp.c
+++ b/src/bimp.c
@@ -32,6 +32,18 @@
 #include "bimp-utils.h"
 #include "plugin-intl.h"
 
+GSList* bimp_input_filenames;
+char* bimp_output_folder;
+
+gint bimp_opt_alertoverwrite;
+gboolean bimp_opt_keepfolderhierarchy;
+gboolean bimp_opt_deleteondone;
+gboolean bimp_opt_keepdates;
+
+gboolean bimp_is_busy;
+
+GSList* bimp_supported_procedures;
+
 static void query (void);
 static gboolean pdb_proc_has_compatible_params (gchar*);
 
@@ -43,7 +55,7 @@ static void run (
     GimpParam **return_vals
     );
 
-const GimpPlugInInfo PLUG_IN_INFO = {
+static const GimpPlugInInfo PLUG_IN_INFO = {
     NULL,  /* init_proc  */
     NULL,  /* quit_proc  */
     query, /* query_proc */

--- a/src/bimp.h
+++ b/src/bimp.h
@@ -20,17 +20,17 @@
 #define BIMP_OVERWRITE_SKIP_ASK 1
 #define BIMP_DONT_OVERWRITE_SKIP_ASK 2
 
-GSList* bimp_input_filenames;
-char* bimp_output_folder;
+extern GSList* bimp_input_filenames;
+extern char* bimp_output_folder;
 
-gint bimp_opt_alertoverwrite;
-gboolean bimp_opt_keepfolderhierarchy;
-gboolean bimp_opt_deleteondone;
-gboolean bimp_opt_keepdates;
+extern gint bimp_opt_alertoverwrite;
+extern gboolean bimp_opt_keepfolderhierarchy;
+extern gboolean bimp_opt_deleteondone;
+extern gboolean bimp_opt_keepdates;
 
-gboolean bimp_is_busy;
+extern gboolean bimp_is_busy;
 
-GSList* bimp_supported_procedures;
+extern GSList* bimp_supported_procedures;
 void init_supported_procedures(void);
 
 #endif

--- a/src/manipulation-gui/gui-changeformat.c
+++ b/src/manipulation-gui/gui-changeformat.c
@@ -8,17 +8,17 @@ static void update_frame_params(GtkComboBox*, changeformat_settings);
 static void adv_expanded (GtkWidget*, GtkRequisition*, gpointer);
 static void update_window_size();
 
-GtkWidget *frame_params, *inner_widget;
-GtkWidget *combo_format, *scale_quality, *scale_alpha_quality, *scale_smoothing, *check_interlace, *scale_compression, *check_baseline;
-GtkWidget *check_rle, *check_progressive, *check_entrophy, *combo_compression, *spin_markers, *combo_subsampling, *combo_dct, *combo_origin;
-GtkWidget *check_savebgc, *check_savegamma, *check_saveoff, *check_savephys, *check_savetime, *check_savecomm, *check_savetrans, *check_lossless;
-GtkWidget *combo_preset, *check_saveexif, *check_savexmp, *check_savecp;
-GtkWidget *expander_advanced;
+static GtkWidget *frame_params, *inner_widget;
+static GtkWidget *combo_format, *scale_quality, *scale_alpha_quality, *scale_smoothing, *check_interlace, *scale_compression, *check_baseline;
+static GtkWidget *check_rle, *check_progressive, *check_entrophy, *combo_compression, *spin_markers, *combo_subsampling, *combo_dct, *combo_origin;
+static GtkWidget *check_savebgc, *check_savegamma, *check_saveoff, *check_savephys, *check_savetime, *check_savecomm, *check_savetrans, *check_lossless;
+static GtkWidget *combo_preset, *check_saveexif, *check_savexmp, *check_savecp;
+static GtkWidget *expander_advanced;
 
-GtkTextBuffer *buffer_comment;
-GtkTextIter start_comment, end_comment;
+static GtkTextBuffer *buffer_comment;
+static GtkTextIter start_comment, end_comment;
 
-GtkWidget* parentwin;
+static GtkWidget* parentwin;
 
 GtkWidget* bimp_changeformat_gui_new(changeformat_settings settings, GtkWidget* parent)
 {

--- a/src/manipulation-gui/gui-color.c
+++ b/src/manipulation-gui/gui-color.c
@@ -6,9 +6,9 @@
 
 static void toggle_curve(GtkToggleButton*, gpointer);
 
-GtkWidget *scale_bright, *scale_contrast;
-GtkWidget *check_autolevels, *check_grayscale, *check_curve;
-GtkWidget *chooser_curve;
+static GtkWidget *scale_bright, *scale_contrast;
+static GtkWidget *check_autolevels, *check_grayscale, *check_curve;
+static GtkWidget *chooser_curve;
     
 GtkWidget* bimp_color_gui_new(color_settings settings)
 {

--- a/src/manipulation-gui/gui-crop.c
+++ b/src/manipulation-gui/gui-crop.c
@@ -8,11 +8,11 @@ static void toggle_group(GtkToggleButton*, gpointer);
 static void set_customratio(GtkComboBox*, gpointer);
 static char* crop_preset_get_string(crop_preset);
 
-GtkWidget *hbox_ratio, *table_manual, *hbox_customratio;
-GtkWidget *radio_stratio, *radio_manual;
-GtkWidget *combo_ratio, *spin_ratio1, *spin_ratio2;
-GtkWidget *spin_width, *spin_height;
-GtkWidget *hbox_startpos, *combo_startpos;
+static GtkWidget *hbox_ratio, *table_manual, *hbox_customratio;
+static GtkWidget *radio_stratio, *radio_manual;
+static GtkWidget *combo_ratio, *spin_ratio1, *spin_ratio2;
+static GtkWidget *spin_width, *spin_height;
+static GtkWidget *hbox_startpos, *combo_startpos;
 
 GtkWidget* bimp_crop_gui_new(crop_settings settings)
 {

--- a/src/manipulation-gui/gui-fliprotate.c
+++ b/src/manipulation-gui/gui-fliprotate.c
@@ -7,7 +7,7 @@
 #include "../bimp-utils.h"
 #include "../plugin-intl.h"
     
-GtkWidget *button_flipH, *button_flipV, *combo_rotate;
+static GtkWidget *button_flipH, *button_flipV, *combo_rotate;
 
 GtkWidget* bimp_fliprotate_gui_new(fliprotate_settings settings)
 {

--- a/src/manipulation-gui/gui-rename.c
+++ b/src/manipulation-gui/gui-rename.c
@@ -9,7 +9,7 @@
 #include "../plugin-intl.h"
 
 static void check_entrytext (GtkEditable*, gpointer);
-GtkWidget *entry_pattern, *label_preview;
+static GtkWidget *entry_pattern, *label_preview;
 
 GtkWidget* bimp_rename_gui_new(rename_settings settings, GtkWidget* parent)
 {

--- a/src/manipulation-gui/gui-resize.c
+++ b/src/manipulation-gui/gui-resize.c
@@ -11,17 +11,17 @@ static void toggle_resolution(GtkToggleButton*, gpointer);
 static void update_dimensions();
 
 
-GtkWidget *table_res;
-GtkWidget *check_resolution;
-GtkWidget *combo_unitW, *combo_unitH, *combo_aspectratio, *combo_quality;
-GtkWidget *chooser_paddingcolor;
-GtkWidget *spin_width, *spin_height, *spin_resX, *spin_resY;
+static GtkWidget *table_res;
+static GtkWidget *check_resolution;
+static GtkWidget *combo_unitW, *combo_unitH, *combo_aspectratio, *combo_quality;
+static GtkWidget *chooser_paddingcolor;
+static GtkWidget *spin_width, *spin_height, *spin_resX, *spin_resY;
 
-resize_mode previous_resize_w, previous_resize_h;
-gdouble last_percent_w_value;
-gdouble last_percent_h_value;
-gint last_pixel_w_value;
-gint last_pixel_h_value;
+static resize_mode previous_resize_w, previous_resize_h;
+static gdouble last_percent_w_value;
+static gdouble last_percent_h_value;
+static gint last_pixel_w_value;
+static gint last_pixel_h_value;
 
 GtkWidget* bimp_resize_gui_new(resize_settings settings)
 {

--- a/src/manipulation-gui/gui-sharpblur.c
+++ b/src/manipulation-gui/gui-sharpblur.c
@@ -4,7 +4,7 @@
 #include "../bimp-manipulations.h"
 #include "../plugin-intl.h"
 
-GtkWidget *scale_sharpblur;
+static GtkWidget *scale_sharpblur;
 
 GtkWidget* bimp_sharpblur_gui_new(sharpblur_settings settings)
 {

--- a/src/manipulation-gui/gui-userdef.c
+++ b/src/manipulation-gui/gui-userdef.c
@@ -16,14 +16,14 @@ static gboolean select_procedure (GtkTreeSelection*, GtkTreeModel*, GtkTreePath*
 static void update_selected_procedure(gchar*);
 static void update_procedure_box(userdef_settings);
 
-GtkWidget *treeview_procedures;
-GtkWidget *scroll_procparam, *vbox_procparam;
-GtkWidget *parent_dialog;
+static GtkWidget *treeview_procedures;
+static GtkWidget *scroll_procparam, *vbox_procparam;
+static GtkWidget *parent_dialog;
 
-userdef_settings temp_settings;
-GtkWidget **param_widget; /* array of showable widgets for customizing the selected procedure */
+static userdef_settings temp_settings;
+static GtkWidget **param_widget; /* array of showable widgets for customizing the selected procedure */
 
-GtkTreeSelection *treesel_proc;
+static GtkTreeSelection *treesel_proc;
 
 enum
 {

--- a/src/manipulation-gui/gui-watermark.c
+++ b/src/manipulation-gui/gui-watermark.c
@@ -13,13 +13,13 @@ static const char* watermark_pos_get_string(watermark_position);
 static const char* watermark_pos_get_abbreviation(watermark_position);
 static void file_filters_add_patterns(GtkFileFilter*, GtkFileFilter*, ...);
 
-GtkWidget *table_text, *vbox_image, *hbox_image_size;
-GtkWidget *radio_text, *radio_image;
-GtkWidget *entry_text;
-GtkWidget *chooser_font, *chooser_color, *chooser_image;
-GtkWidget *check_image_adaptsize, *spin_image_sizepercent, *spin_edge, *combo_image_sizemode;
-GtkWidget *scale_opacity;
-GtkWidget *position_buttons[9];
+static GtkWidget *table_text, *vbox_image, *hbox_image_size;
+static GtkWidget *radio_text, *radio_image;
+static GtkWidget *entry_text;
+static GtkWidget *chooser_font, *chooser_color, *chooser_image;
+static GtkWidget *check_image_adaptsize, *spin_image_sizepercent, *spin_edge, *combo_image_sizemode;
+static GtkWidget *scale_opacity;
+static GtkWidget *position_buttons[9];
 
 GtkWidget* bimp_watermark_gui_new(watermark_settings settings)
 {


### PR DESCRIPTION
Added 'extern' to all global variable declaration in .h and addedd their definition in respective .c files. All other global variables defined in .c were changed to file scope using the 'static' modifier. The project should now compile under GCC 10.

I have not programmed in C in a long while, so I am not 100% sure these changes won't cause any problems. The plugin now compiles in Fedora 32 using GCC 10.2.1, I haven't yet checked older compilers.

Fixes #234 