### PR TITLE
Makefile: Factor out flags and respect user-defined CFLAGS/LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,21 @@
-GIMPARGS = $(shell gimptool-2.0 --cflags --libs)
+GIMP_CFLAGS = $(shell gimptool-2.0 --cflags)
+GIMP_LIBS = $(shell gimptool-2.0 --libs)
+CFLAGS += $(GIMP_CFLAGS) -Wall -Wno-unused-variable -Wno-pointer-sign -DGIMP_DISABLE_DEPRECATED
+LDFLAGS += $(GIMP_LIBS) -lm
 SYSTEM_INSTALL_DIR = $(shell gimptool-2.0 --dry-run --install-admin-bin ./bin/bimp | sed 's/cp \S* \(\S*\)/\1/'|tr -d [\'])
 USER_INSTALL_DIR = $(shell gimptool-2.0 --dry-run --install-bin ./bin/bimp | sed 's/cp \S* \(\S*\)/\1/'|tr -d [\'])
 
 make: 
 	which gimptool-2.0 && \
-	gcc -o ./bin/bimp -Wall -O2 -Wno-unused-variable -Wno-pointer-sign src/*.c src/manipulation-gui/*.c src/images/*.c $(GIMPARGS) -lm -DGIMP_DISABLE_DEPRECATED
+	gcc -o ./bin/bimp -O2 $(CFLAGS) src/*.c src/manipulation-gui/*.c src/images/*.c $(LDFLAGS)
 
 makewin-debug: 
 	which gimptool-2.0 && \
-	gcc -o ./bin/win32/bimp -Wall -Wno-unused-variable -Wno-pointer-sign src/*.c src/manipulation-gui/*.c src/images/*.c $(GIMPARGS) -lm -DGIMP_DISABLE_DEPRECATED
+	gcc -o ./bin/win32/bimp $(CFLAGS) src/*.c src/manipulation-gui/*.c src/images/*.c $(LDFLAGS)
     
 makewin: 
 	which gimptool-2.0 && \
-	gcc -mwindows -o ./bin/win32/bimp -O2 -Wall -Wno-unused-variable -Wno-pointer-sign src/*.c src/manipulation-gui/*.c src/images/*.c $(GIMPARGS) -lm -DGIMP_DISABLE_DEPRECATED
+	gcc -mwindows -o ./bin/win32/bimp -O2 $(CFLAGS) src/*.c src/manipulation-gui/*.c src/images/*.c $(LDFLAGS)
 		
 install: 
 	mkdir -p "$(USER_INSTALL_DIR)"


### PR DESCRIPTION
This is useful among other things for distro packagers that enforce their base C and link flags:
```
$ rpm --eval %set_build_flags

  CFLAGS="${CFLAGS:--O2 -g -pipe -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fasynchronous-unwind-tables}" ; export CFLAGS ; 
  CXXFLAGS="${CXXFLAGS:--O2 -g -pipe -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fasynchronous-unwind-tables}" ; export CXXFLAGS ; 
  FFLAGS="${FFLAGS:--O2 -g -pipe -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fasynchronous-unwind-tables }" ; export FFLAGS ; 
  FCFLAGS="${FCFLAGS:--O2 -g -pipe -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fasynchronous-unwind-tables }" ; export FCFLAGS ; 
  LDFLAGS="${LDFLAGS:- -Wl,--as-needed -Wl,--no-undefined -Wl,-z,relro -Wl,-O1 -Wl,--build-id -Wl,--enable-new-dtags}" ; export LDFLAGS
```