### PR TITLE
Add AVIF support

### DIFF
--- a/src/bimp-gui.c
+++ b/src/bimp-gui.c
@@ -330,6 +330,7 @@ static void add_input_folder_r(char* folder, gboolean with_subdirs)
                 g_ascii_strcasecmp(file_extension, ".tga") == 0 ||
                 g_ascii_strcasecmp(file_extension, ".svg") == 0 ||
                 g_ascii_strcasecmp(file_extension, ".webp") == 0 ||
+                g_ascii_strcasecmp(file_extension, ".avif") == 0 ||
                 g_ascii_strcasecmp(file_extension, ".xpm") == 0 ||
                 g_ascii_strcasecmp(file_extension, ".exr") == 0 ||
                 g_ascii_strcasecmp(file_extension, ".dds") == 0 ||
@@ -593,7 +594,7 @@ static void open_file_chooser(GtkWidget *widget, gpointer data)
 {
     GSList *selection;
     
-    GtkFileFilter *filter_all, *supported[15];
+    GtkFileFilter *filter_all, *supported[16];
 
     GtkWidget* file_chooser = gtk_file_chooser_dialog_new(
         _("Select images"), 
@@ -676,23 +677,28 @@ static void open_file_chooser(GtkWidget *widget, gpointer data)
     gtk_file_filter_add_pattern (filter_all, "*.[wW][eE][bB][pP]");
 
     supported[12] = gtk_file_filter_new();
-    gtk_file_filter_set_name(supported[12], "XPM (*.xpm)");
-    gtk_file_filter_add_pattern (supported[12], "*.[xX][pP][mM]");
-    gtk_file_filter_add_pattern (filter_all, "*.[xX][pP][mM]");
+    gtk_file_filter_set_name(supported[12], "AVIF (*.avif)");
+    gtk_file_filter_add_pattern (supported[12], "*.[aA][vV][iI][fF]");
+    gtk_file_filter_add_pattern (filter_all, "*.[aA][vV][iI][fF]");
 
     supported[13] = gtk_file_filter_new();
-    gtk_file_filter_set_name(supported[13], "OpenEXR (*.exr)");
-    gtk_file_filter_add_pattern (supported[13], "*.[eE][xX][rR]");
-    gtk_file_filter_add_pattern (filter_all, "*.[eE][xX][rR]");
+    gtk_file_filter_set_name(supported[13], "XPM (*.xpm)");
+    gtk_file_filter_add_pattern (supported[13], "*.[xX][pP][mM]");
+    gtk_file_filter_add_pattern (filter_all, "*.[xX][pP][mM]");
 
     supported[14] = gtk_file_filter_new();
-    gtk_file_filter_set_name(supported[14], "GIMP XCF (*.xcf)");
-    gtk_file_filter_add_pattern (supported[14], "*.[xX][cC][fF]");
+    gtk_file_filter_set_name(supported[14], "OpenEXR (*.exr)");
+    gtk_file_filter_add_pattern (supported[14], "*.[eE][xX][rR]");
+    gtk_file_filter_add_pattern (filter_all, "*.[eE][xX][rR]");
+
+    supported[15] = gtk_file_filter_new();
+    gtk_file_filter_set_name(supported[15], "GIMP XCF (*.xcf)");
+    gtk_file_filter_add_pattern (supported[15], "*.[xX][cC][fF]");
     gtk_file_filter_add_pattern (filter_all, "*.[xX][cC][fF]");
         
     gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(file_chooser), filter_all);
     size_t i;
-    for(i = 0; i < 15; i++) {
+    for(i = 0; i < 16; i++) {
         gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(file_chooser), supported[i]);
     }
     

--- a/src/bimp-manipulations.h
+++ b/src/bimp-manipulations.h
@@ -81,6 +81,7 @@ typedef enum format_type {
     FORMAT_TIFF,
     FORMAT_HEIF,
     FORMAT_WEBP,
+    FORMAT_AVIF,
     FORMAT_EXR,
     FORMAT_END
 } format_type;
@@ -94,6 +95,7 @@ static const char* format_type_string[][2] = {
     {"tiff", "Tagged Image File Format (.tiff)"},       /* FORMAT_TIFF */
     {"heif", "Heif (.heif)"},                           /* FORMAT_HEIF */
     {"webp", "WebP (.webp)"},                           /* FORMAT_WEBP */
+    {"avif", "AV1 Image Format (.avif)"},               /* FORMAT_AVIF */
     {"exr", "OpenEXR (.exr)"}                           /* FORMAT_EXR */
 };
 
@@ -250,6 +252,11 @@ typedef struct changeformat_params_webp {
     int delay;
     int force_delay;
 } *format_params_webp;
+
+typedef struct changeformat_params_avif {
+    gboolean lossless;
+    int quality;
+} *format_params_avif;
 
 typedef struct manip_rename_set {
     gchar* pattern;

--- a/src/bimp-operate.c
+++ b/src/bimp-operate.c
@@ -39,6 +39,7 @@ static gboolean image_save_png(image_output, gboolean, int, gboolean, gboolean, 
 static gboolean image_save_tga(image_output, gboolean, int);
 static gboolean image_save_tiff(image_output, int);
 static gboolean image_save_webp(image_output, int, gboolean, float, float, gboolean, gboolean, gboolean, int, gboolean, gboolean, gboolean, int, int);
+static gboolean image_save_avif(image_output, gboolean, int);
 static gboolean image_save_exr(image_output);
 
 static int overwrite_result(char*, GtkWidget*);
@@ -1094,6 +1095,13 @@ static gboolean image_save(format_type type, image_output imageout, format_param
             ((format_params_webp)params)->force_delay
         );
     }
+    else if(type == FORMAT_AVIF) {
+        result = image_save_avif(
+            imageout,
+            ((format_params_avif)params)->lossless,
+            ((format_params_avif)params)->quality
+        );
+    }
     else if(type == FORMAT_EXR) {
         result = image_save_exr(imageout);
     }
@@ -1379,6 +1387,25 @@ static gboolean image_save_webp(image_output out, int preset, gboolean lossless,
     );
     
     return TRUE;
+}
+
+static gboolean image_save_avif(image_output out, gboolean lossless, int quality) 
+{
+    gint nreturn_vals;
+    int final_drawable = gimp_image_merge_visible_layers(out->image_id, GIMP_CLIP_TO_IMAGE);
+
+    GimpParam *return_vals = gimp_run_procedure(
+        "file_heif_av1_save",
+        &nreturn_vals,
+        GIMP_PDB_INT32, GIMP_RUN_NONINTERACTIVE,
+        GIMP_PDB_IMAGE, out->image_id,
+        GIMP_PDB_DRAWABLE, final_drawable,
+        GIMP_PDB_STRING, out->filepath,
+        GIMP_PDB_STRING, out->filename,
+        GIMP_PDB_INT32, quality,           // Quality of the image (0 <= quality <= 100)
+        GIMP_PDB_INT32, lossless,          // Use lossless encoding (0/1)
+        GIMP_PDB_END
+    );
 }
 
 static gboolean image_save_exr(image_output out) 

--- a/src/bimp-serialize.c
+++ b/src/bimp-serialize.c
@@ -728,6 +728,11 @@ static void write_changeformat(changeformat_settings settings, GKeyFile* file)
         g_key_file_set_integer(file, group_name, "delay", params->delay);
         g_key_file_set_integer(file, group_name, "force_delay", params->force_delay);
     }
+    else if(settings->format == FORMAT_AVIF) {
+        format_params_avif params = settings->params;
+        g_key_file_set_boolean(file, group_name, "lossless", params->lossless);
+        g_key_file_set_integer(file, group_name, "quality", params->quality);
+    }
 }
 
 static manipulation read_changeformat(GKeyFile* file) 
@@ -880,6 +885,16 @@ static manipulation read_changeformat(GKeyFile* file)
 
                 if (g_key_file_has_key(file, group_name, "force_delay", NULL)) 
                     params->force_delay = g_key_file_get_integer(file, group_name, "force_delay", NULL);
+            }
+            else if (settings->format == FORMAT_AVIF) {
+                settings->params = (format_params_avif) g_malloc(sizeof(struct changeformat_params_avif));
+                format_params_avif params = settings->params;
+
+                if (g_key_file_has_key(file, group_name, "lossless", NULL)) 
+                    params->lossless = g_key_file_get_boolean(file, group_name, "lossless", NULL);
+
+                if (g_key_file_has_key(file, group_name, "quality", NULL)) 
+                    params->quality = g_key_file_get_integer(file, group_name, "quality", NULL);
             }
         }
     }

--- a/src/manipulation-gui/gui-changeformat.c
+++ b/src/manipulation-gui/gui-changeformat.c
@@ -399,6 +399,34 @@ static void update_frame_params(GtkComboBox *widget, changeformat_settings setti
         gtk_box_pack_start(GTK_BOX(inner_widget), check_savexmp, TRUE, TRUE, 0);
         gtk_box_pack_start(GTK_BOX(inner_widget), check_savecp, TRUE, TRUE, 0);
     }
+    else if (selected_format == FORMAT_AVIF) {
+        GtkWidget *hbox_quality, *label_quality;
+
+        check_lossless = gtk_check_button_new_with_label(_("Nearly lossless"));
+
+        hbox_quality = gtk_hbox_new(FALSE, 5);
+        label_quality = gtk_label_new(g_strconcat(_("Quality"), ":", NULL));
+        gtk_misc_set_alignment(GTK_MISC(label_quality), 0.5, 0.8);
+        scale_quality = gtk_hscale_new_with_range(0, 100, 1);
+
+        if (selected_format == settings->format) {
+            format_params_avif settings_avif = (format_params_avif)(settings->params);
+            gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(check_lossless), settings_avif->lossless);
+            
+            gtk_range_set_value(GTK_RANGE(scale_quality), settings_avif->quality);      
+        }
+        else {
+            gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(check_lossless), FALSE);
+
+            gtk_range_set_value(GTK_RANGE(scale_quality), 50);
+        }
+
+        gtk_box_pack_start(GTK_BOX(inner_widget), check_lossless, FALSE, FALSE, 0);
+
+        gtk_box_pack_start(GTK_BOX(hbox_quality), label_quality, FALSE, FALSE, 0);
+        gtk_box_pack_start(GTK_BOX(hbox_quality), scale_quality, TRUE, TRUE, 0);
+        gtk_box_pack_start(GTK_BOX(inner_widget), hbox_quality, TRUE, TRUE, 0);
+    }
     else {
         GtkWidget *label_no_param ;
         
@@ -491,6 +519,12 @@ void bimp_changeformat_save(changeformat_settings orig_settings)
         ((format_params_webp)orig_settings->params)->kf_distance = 50;
         ((format_params_webp)orig_settings->params)->delay = 200;
         ((format_params_webp)orig_settings->params)->force_delay = FALSE;
+    }
+    else if (orig_settings->format == FORMAT_AVIF) {
+        orig_settings->params = (format_params_avif) g_malloc(sizeof(struct changeformat_params_avif));
+
+        ((format_params_avif)orig_settings->params)->lossless = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(check_lossless));
+        ((format_params_avif)orig_settings->params)->quality = gtk_range_get_value(GTK_RANGE(scale_quality));
     }
     else {
         orig_settings->params = NULL;


### PR DESCRIPTION
Closes #296 

This pull request allows for BIMP to read in AVIF images and also allows for images to be transcoded to/from AVIF. A very good image format with comparable lossy sizes to WebP while retaining image quality. 

I tried to get it as close to the vanilla GIMP encode as possible, but limitations in the `save-heif-av1-file` procedure didn't allow for me to add in bit depth and color profile properties. 

I tested this a bit on Linux and managed to encode it with no issues, though I can't seem to figure out how to compile for Windows as gcc doesn't know what `-mwindows` is on the makewin profile. If there is any way for me to test this on Windows I'd love to try it out.